### PR TITLE
Add TS dependency and deploy commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "@nomicfoundation/hardhat-toolbox": "^1.0.2",
         "hardhat": "^2.10.2",
         "hardhat-contract-sizer": "^2.6.1",
-        "hardhat-gas-reporter": "^1.0.8"
+        "hardhat-gas-reporter": "^1.0.8",
+        "typescript": "^4.8.3"
       }
     },
     "node_modules/@colors/colors": {
@@ -9656,11 +9657,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18507,11 +18507,10 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "peer": true
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "typical": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "version": "0.1.0",
   "description": "Set of sample contracts created using RMRK standard package: @rmrk-team/evm-contracts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "deploy-equippable": "hardhat run scripts/deployEquippable.ts",
+    "deploy-multiresource": "hardhat run scripts/deployMultiresource.ts",
+    "deploy-nesting": "hardhat run scripts/deployNesting.ts",
+    "deploy-nesting-multiresource": "hardhat run scripts/deployNestingMultiresource.ts",
+    "deploy-split-equippable": "hardhat run scripts/deploySplitEquippable.ts"
   },
   "keywords": [],
   "author": "@rmrk-team",
@@ -15,6 +20,7 @@
     "@nomicfoundation/hardhat-toolbox": "^1.0.2",
     "hardhat": "^2.10.2",
     "hardhat-contract-sizer": "^2.6.1",
-    "hardhat-gas-reporter": "^1.0.8"
+    "hardhat-gas-reporter": "^1.0.8",
+    "typescript": "^4.8.3"
   }
 }


### PR DESCRIPTION
TS dependency was added, so anyone using the examples can run them out of the box, rather than having to add it as a global dependency.

Custom scripts in the package.json allow people to run the example scripts as soon as they install the dependencies. This way they can experience the expected behaviour before digging into the code.