### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The Github accounts listed here will automatically be requested to review PRs.
+*       @steven2308 @ThunderDeliverer


### PR DESCRIPTION
Added CODEOWNERS, so that we are sutomatically assigned as PR reviewers.